### PR TITLE
[TASK] Refine display and grouping of select items

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -3,7 +3,12 @@ defined('TYPO3_MODE') or die('Access denied.');
 
 (function () {
     $dokType = '24';
-    $newsType = ['LLL:EXT:newspage/Resources/Private/Language/locallang_be.xlf:news', $dokType];
+    $newsType = [
+        'LLL:EXT:newspage/Resources/Private/Language/locallang_be.xlf:news',
+        $dokType,
+        'apps-pagetree-newspage-page',
+        'default',
+    ];
 
     // adding the new doktypes to the type select
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem('pages', 'doktype', $newsType);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -18,7 +18,8 @@ defined('TYPO3_MODE') or die('Access denied.');
             $ext,
             $plugin,
             $locallang . ':' . strtolower($plugin) . '.label',
-            'EXT:newspage/Resources/Public/Icons/Extension.svg'
+            'EXT:newspage/Resources/Public/Icons/Extension.svg',
+            'newspage',
         );
         $GLOBALS['TCA']['tt_content']['types'][$pluginSignature] = $GLOBALS['TCA']['tt_content']['types']['header']; // TODO: why this type?
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
@@ -32,4 +33,12 @@ defined('TYPO3_MODE') or die('Access denied.');
         $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'][',' . $pluginSignature] =
             $flexformPath . $plugin . '.xml';
     }
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItemGroup(
+        'tt_content',
+        'CType',
+        'newspage',
+        'Newspage Plugins',
+        'before:lists'
+    );
 })();


### PR DESCRIPTION
This change groups the plugins provided with this extension into a single Selectitem Group, moves the new doktype into the "default" grouping, and adds the newspage icon to the selected doktype dropdown display.