### PR TITLE
[BUGFIX] Add event listener to provide filter functionality in TYPO3 12

### DIFF
--- a/Classes/EventListener/FlexFormPreFilterProvider.php
+++ b/Classes/EventListener/FlexFormPreFilterProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace B13\Newspage\EventListener;
+
+/*
+  * This file is part of TYPO3 CMS-based extension "newspage" by b13.
+  *
+  * It is free software; you can redistribute it and/or modify it under
+  * the terms of the GNU General Public License, either version 2
+  * of the License, or any later version.
+  */
+
+use TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureParsedEvent;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class FlexFormPreFilterProvider
+{
+
+    public function __invoke(AfterFlexFormDataStructureParsedEvent $event): void
+    {
+        $identifier = $event->getIdentifier();
+        if ($identifier['type'] === 'tca' && $identifier['tableName'] === 'tt_content' && $identifier['dataStructureKey'] === ',newspage_list') {
+            $dataStructure = $event->getDataStructure();
+            foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['newspage']['filters'] as $type => $filter) {
+                if ($filter['flexForm'] !== '') {
+                    $file = GeneralUtility::getFileAbsFileName($filter['flexForm']);
+                    $content = file_get_contents($file);
+                    if ($content) {
+                        $dataStructure['sheets']['preFilters']['ROOT']['el']['settings.prefilters.' . strtolower($type)] = \TYPO3\CMS\Core\Utility\GeneralUtility::xml2array($content);
+                    }
+                }
+            }
+            $event->setDataStructure($dataStructure);
+        }
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -23,3 +23,8 @@ services:
     tags:
       - name: event.listener
         identifier: 'ext-newspage-newsLayoutListener'
+
+  B13\Newspage\EventListener\FlexFormPreFilterProvider:
+    tags:
+      - name: event.listener
+        identifier: 'ext-newspage-flexFormPreFilterProvider'


### PR DESCRIPTION
TYPO3 12 added new events for modifying FlexForm Data, but newspage has not had its hook updated to an EventListener yet.

This pull request restores the ability to filter a list in the flexform of the plugin with TYPO3 12.