### PR TITLE
[BUGFIX] Add filter options if preFilter exists, but is empty

### DIFF
--- a/Classes/Controller/NewsController.php
+++ b/Classes/Controller/NewsController.php
@@ -91,7 +91,7 @@ class NewsController extends ActionController
     {
         $filterOptions = [];
         foreach (explode(',', $this->settings['filter']['by'] ?? []) as $filter) {
-            if (!in_array(strtolower($filter), $this->preFilters)) {
+            if (!in_array(strtolower($filter), $this->preFilters) || empty($this->preFilters[$filter])) {
                 $filterOptions[$filter]['items'] = FilterService::getFilterOptionsForFluid($filter);
             }
         }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,6 +10,7 @@ services:
 
   B13\Newspage\Filter\CategoryFilter:
     public: true
+
   B13\Newspage\Filter\CategoriesFilter:
     public: true
 


### PR DESCRIPTION
If a "pre filter" is selected in the backend, the frontend view no longer shows the same filter, even when selected.
Currently it is enough for the pre filter to be rendered in the backend as only the array key existance is checked.

This small patch also checks if a value is actually selected before "hiding" the filter in the frontend.